### PR TITLE
Nit: releases x86_64, not x86.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Redis Cluster Manager in Crystal
 
 ## Installation
 
-#### Static Binary is ready for x86 linux
+#### Static Binary is ready for x86_64 linux
 
 - https://github.com/maiha/rcm.cr/releases
 


### PR DESCRIPTION
```
% file rcm
rcm: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked, for GNU/Linux 2.6.32, BuildID[sha1]=0x83928d51353deea531dea04e96874b60e0551356, not stripped
```